### PR TITLE
Move docker hooks to /usr/lib/docker/hooks.d

### DIFF
--- a/oci-systemd-hook.spec
+++ b/oci-systemd-hook.spec
@@ -20,14 +20,14 @@ OCI systemd hooks enable running systemd in a OCI runc/docker container.
 
 %build
 autoreconf -i
-%configure --libexecdir=/usr/libexec/docker/hooks.d/
+%configure --libexecdir=/usr/lib/docker/hooks.d/
 make %{?_smp_mflags}
 
 %install
 %make_install
 
 %files
-%{_libexecdir}/docker/hooks.d/oci_systemd_hook
+%{_libdir}/docker/hooks.d/oci_systemd_hook
 %{_mandir}/man1/oci_systemd_hook.1*
 %doc README.md LICENSE
 


### PR DESCRIPTION
Since we have removed dockerinit from /usr/libexec/docker, I think we should
standarize to to /usr/lib/docker/hooks.d for location of hooks.

The docker-1.10.1 package is looking here for this location now.