### PR TITLE
Mount all cgroup file systems on host system r/o into container

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,6 +5,8 @@ oci_systemd_hook_CFLAGS = $(YAJL_CFLAGS)
 oci_systemd_hook_LDADD = $(YAJL_LIBS)
 oci_systemd_hook_CFLAGS += $(SELINUX_CFLAGS)
 oci_systemd_hook_LDADD += $(SELINUX_LIBS)
+oci_systemd_hook_CFLAGS += $(LIBMOUNT_CFLAGS)
+oci_systemd_hook_LDADD += $(LIBMOUNT_LIBS)
 
 dist_man_MANS = oci_systemd_hook.1
 EXTRA_DIST = README.md LICENSE

--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,7 @@ AC_PROG_CC
 
 PKG_CHECK_MODULES([YAJL], [yajl >= 2.0.0])
 PKG_CHECK_MODULES([SELINUX], [libselinux >= 2.0.0])
+PKG_CHECK_MODULES([LIBMOUNT], [mount >= 2.27.0])
 
 AC_MSG_CHECKING([whether to disable argument checking])
 AC_ARG_ENABLE([args], AS_HELP_STRING([--disable-args], [disable checking that cmd args are either init/systemd]))


### PR DESCRIPTION
Find all of the cgroup file systems under /sys/fs/cgroup and bind
mount them read/only into the container except for /sys/fs/cgroup/systemd